### PR TITLE
Fix a typo so that bad comm at startup isn't fatal

### DIFF
--- a/NanoVNASaver/Hardware/Hardware.py
+++ b/NanoVNASaver/Hardware/Hardware.py
@@ -69,7 +69,7 @@ def get_VNA(app, serial_port: serial.Serial) -> 'VNA':
 
     for _ in range(3):
         vnaType = detect_version(serial_port)
-        if vnaType != "unkown":
+        if vnaType != "unknown":
             break
 
     serial_port.timeout = 0.2


### PR DESCRIPTION
This is a simple typo with repurcussions. Just a one-liner repair. Thanks.