### PR TITLE
repair multi segment sweeps for v2

### DIFF
--- a/NanoVNASaver/Hardware/NanoVNA_V2.py
+++ b/NanoVNASaver/Hardware/NanoVNA_V2.py
@@ -185,6 +185,8 @@ class NanoVNAV2(VNA):
 
 
     def setSweep(self, start, stop):
+        if(len(self.sweepData) != self.datapoints) :
+            self.sweepData = [(0, 0)] * self.datapoints
         step = (stop - start) / (self.datapoints - 1)
         if start == self.sweepStartHz and step == self.sweepStepHz:
             return


### PR DESCRIPTION
Some of the code relies on checking the returned sweep data length so make it the same as the requested number of datapoints.

You may wish to do this a different way, like just returning part of the sweepData array or counting the data differently in the sweepworker, but this does seem to work and shouldn't have a performance penalty.